### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-publish-drunk.yml
+++ b/.github/workflows/build-publish-drunk.yml
@@ -2,6 +2,10 @@
 
 name: build-publish
 
+permissions:
+  contents: write
+  packages: write
+
 on:
   push:
     branches: ['main']


### PR DESCRIPTION
Potential fix for [https://github.com/baoduy/drunk-pulumi-azure-components/security/code-scanning/1](https://github.com/baoduy/drunk-pulumi-azure-components/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow:
- `contents: read` is needed for actions like `actions/checkout` to read the repository contents.
- `contents: write` is required for creating releases using `actions/create-release`.
- `packages: write` is required for publishing to npm.

The `permissions` block will be added at the root level, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
