### PR TITLE
Potential fix for code scanning alert no. 2: Regular expression injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "@pulumi/pulumi": "^3.167.0",
     "@pulumi/random": "^4.18.2",
     "netmask": "^2.0.2",
-    "openpgp": "^6.1.0"
+    "openpgp": "^6.1.0",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/src/vault/helpers.ts
+++ b/src/vault/helpers.ts
@@ -1,7 +1,9 @@
 import { rsHelpers, stackInfo } from '../helpers';
+import _ from 'lodash';
 
 export function getSecretName(name: string) {
-  const n = name.replace(new RegExp(stackInfo.stack, 'g'), ''); // Replace occurrences of "stack" variable with "-"
+  const sanitizedStack = _.escapeRegExp(stackInfo.stack);
+  const n = name.replace(new RegExp(sanitizedStack, 'g'), ''); // Replace occurrences of "stack" variable with "-"
 
   return rsHelpers.getNameNormalize(n);
 }


### PR DESCRIPTION
Potential fix for [https://github.com/baoduy/drunk-pulumi-azure-components/security/code-scanning/2](https://github.com/baoduy/drunk-pulumi-azure-components/security/code-scanning/2)

To fix the issue, the `stackInfo.stack` value should be sanitized before being used in the `RegExp` constructor. The recommended approach is to use a library like `lodash` and its `_.escapeRegExp` function to escape special characters in the input. This ensures that the input cannot modify the behavior of the regular expression.

**Steps to fix:**
1. Import the `lodash` library in the file where the issue occurs.
2. Use `_.escapeRegExp(stackInfo.stack)` to sanitize the `stackInfo.stack` value before passing it to the `RegExp` constructor.
3. Ensure that the functionality remains unchanged, i.e., the regex still matches occurrences of the sanitized `stackInfo.stack` value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
