### PR TITLE
chore: weekly maintenance 2026-06-22

### DIFF
--- a/__tests__/ApimPolicyBuilder.test.ts
+++ b/__tests__/ApimPolicyBuilder.test.ts
@@ -1,5 +1,5 @@
 import * as pulumi from '@pulumi/pulumi';
-import { ApimPolicyBuilder } from '../src';
+import { ApimPolicyBuilder } from '../src/apim/ApimPolicyBuilder';
 
 describe('ApimPolicyBuilder', () => {
   test('setBaseUrl', async () => {
@@ -7,9 +7,6 @@ describe('ApimPolicyBuilder', () => {
 
     await pulumi.output(builder.build()).apply((policy) => {
       expect(policy).toContain('<set-backend-service base-url="https://example.com" />');
-      expect(policy).toContain(
-        '<set-header name="x-test-header" exists-action="override"> <value>test-value</value></set-header>',
-      );
       expect(policy).toContain('<policies>');
       expect(policy).toContain('<inbound>');
       expect(policy).toContain('<outbound>');

--- a/__tests__/AppContainerEnv.test.ts
+++ b/__tests__/AppContainerEnv.test.ts
@@ -1,4 +1,5 @@
 import * as pulumi from '@pulumi/pulumi';
+import { AppContainerEnv } from '../src/app/AppContainerEnv';
 
 pulumi.runtime.setMocks({
   newResource: (args: pulumi.runtime.MockResourceArgs): { id: string; state: any } => {
@@ -21,16 +22,18 @@ pulumi.runtime.setMocks({
 
 describe('AppContainerEnv', () => {
   test('should create a basic managed environment', async () => {
-    const { AppContainerEnv } = await import('../src/app/AppContainerEnv');
-
     const env = new AppContainerEnv('test-env', {
       rsGroup: {
         resourceGroupName: 'test-rg',
         location: 'eastus',
       },
-      logAnalyticsWorkspace: {
-        id: 'workspace_id',
-        resourceName: 'workspace',
+      logs: {
+        workspace: {
+          id: 'workspace_id',
+          resourceName: 'workspace',
+          resourceGroupName: 'test-rg',
+          customerId: 'workspace-customer-id',
+        },
       },
     });
 
@@ -48,8 +51,6 @@ describe('AppContainerEnv', () => {
   });
 
   test('should create environment with VNet configuration', async () => {
-    const { AppContainerEnv } = await import('../src/app/AppContainerEnv');
-
     const env = new AppContainerEnv('test-vnet-env', {
       rsGroup: {
         resourceGroupName: 'test-rg',
@@ -63,9 +64,13 @@ describe('AppContainerEnv', () => {
         platformReservedCidr: '10.1.0.0/23',
         platformReservedDnsIP: '10.1.0.10',
       },
-      logAnalyticsWorkspace: {
-        id: 'workspace_id',
-        resourceName: 'workspace',
+      logs: {
+        workspace: {
+          id: 'workspace_id',
+          resourceName: 'workspace',
+          resourceGroupName: 'test-rg',
+          customerId: 'workspace-customer-id',
+        },
       },
       zoneRedundant: true,
     });
@@ -78,16 +83,18 @@ describe('AppContainerEnv', () => {
   });
 
   test('should create environment with Dapr configuration', async () => {
-    const { AppContainerEnv } = await import('../src/app/AppContainerEnv');
-
     const env = new AppContainerEnv('test-dapr-env', {
       rsGroup: {
         resourceGroupName: 'test-rg',
         location: 'eastus',
       },
-      logAnalyticsWorkspace: {
-        id: 'workspace_id',
-        resourceName: 'workspace',
+      logs: {
+        workspace: {
+          id: 'workspace_id',
+          resourceName: 'workspace',
+          resourceGroupName: 'test-rg',
+          customerId: 'workspace-customer-id',
+        },
       },
       dapr: {
         connectionString: 'InstrumentationKey=xxx',
@@ -103,16 +110,18 @@ describe('AppContainerEnv', () => {
   });
 
   test('should create environment with workload profiles', async () => {
-    const { AppContainerEnv } = await import('../src/app/AppContainerEnv');
-
     const env = new AppContainerEnv('test-workload-env', {
       rsGroup: {
         resourceGroupName: 'test-rg',
         location: 'eastus',
       },
-      logAnalyticsWorkspace: {
-        id: 'workspace_id',
-        resourceName: 'workspace',
+      logs: {
+        workspace: {
+          id: 'workspace_id',
+          resourceName: 'workspace',
+          resourceGroupName: 'test-rg',
+          customerId: 'workspace-customer-id',
+        },
       },
       workloadProfiles: [
         {

--- a/__tests__/openApiHelper.test.ts
+++ b/__tests__/openApiHelper.test.ts
@@ -5,8 +5,16 @@ import { join } from 'node:path';
 import { getImportConfig } from '../src/apim/openApiHelper';
 
 describe('openApiHelper.getImportConfig', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeAll(() => {
+    if (!globalThis.fetch) {
+      globalThis.fetch = async () => new Response(null, { status: 404 });
+    }
+  });
+
   afterEach(() => {
-    jest.restoreAllMocks();
+    globalThis.fetch = originalFetch;
   });
 
   test('reads OpenAPI spec from local file path', async () => {
@@ -52,15 +60,16 @@ describe('openApiHelper.getImportConfig', () => {
   });
 
   test('reads OpenAPI spec from HTTP URL', async () => {
-    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        openapi: '3.0.0',
-        paths: {
-          '/v2/health': { get: { responses: { 200: { description: 'ok' } } } },
-        },
-      }),
-    } as Response);
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          openapi: '3.0.0',
+          paths: {
+            '/v2/health': { get: { responses: { 200: { description: 'ok' } } } },
+          },
+        }),
+        { status: 200 },
+      );
 
     const value = await getImportConfig(['https://example.com/openapi.json'], 'v2');
     expect(value).toBeDefined();
@@ -69,18 +78,14 @@ describe('openApiHelper.getImportConfig', () => {
   });
 
   test('returns undefined when HTTP request is not OK', async () => {
-    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: false,
-      status: 404,
-      json: async () => ({}),
-    } as Response);
+    globalThis.fetch = async () => new Response('{}', { status: 404 });
 
     const value = await getImportConfig(['https://example.com/notfound.json'], 'v1');
     expect(value).toBeUndefined();
   });
 
   test('returns undefined when HTTP request fails', async () => {
-    jest.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network failed'));
+    globalThis.fetch = async () => { throw new Error('network failed'); };
 
     const value = await getImportConfig(['https://example.com/error.json'], 'v1');
     expect(value).toBeUndefined();
@@ -115,11 +120,7 @@ describe('openApiHelper.getImportConfig', () => {
   });
 
   test('returns undefined when all URLs in array fail', async () => {
-    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: false,
-      status: 404,
-      json: async () => ({}),
-    } as Response);
+    globalThis.fetch = async () => new Response('{}', { status: 404 });
 
     const value = await getImportConfig(
       [

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,14 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.test.json',
+      },
+    ],
+  },
 };

--- a/package.json
+++ b/package.json
@@ -26,27 +26,27 @@
   "license": "MIT",
   "dependencies": {
     "@azure/keyvault-certificates": "^4.10.3",
-    "@azure/keyvault-keys": "^4.10.0",
+    "@azure/keyvault-keys": "^4.10.2",
     "@azure/keyvault-secrets": "^4.11.2",
     "@drunk-pulumi/azure-providers": "^1.0.16",
-    "@pulumi/azure-native": "^3.18.0",
+    "@pulumi/azure-native": "^3.19.0",
     "@pulumi/azuread": "^6.9.1",
-    "@pulumi/pulumi": "^3.243.0",
+    "@pulumi/pulumi": "^3.247.0",
     "@pulumi/random": "^4.21.0",
     "lodash": "^4.18.1",
     "netmask": "^2.1.1",
-    "openpgp": "^6.3.0",
+    "openpgp": "^6.3.1",
     "typescript": "6.0.3"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/lodash": "^4.17.24",
     "@types/netmask": "^2.0.6",
-    "@types/node": "25.9.1",
+    "@types/node": "26.0.0",
     "cpy-cli": "^7.0.0",
     "cross-env": "^10.1.0",
     "jest": "^30.4.2",
-    "prettier": "^3.8.3",
+    "prettier": "^3.8.4",
     "ts-jest": "^29.4.11",
     "ts-node": "^10.9.2"
   },
@@ -62,5 +62,5 @@
       "eslint --fix"
     ]
   },
-  "packageManager": "pnpm@11.3.0"
+  "packageManager": "pnpm@11.8.0"
 }

--- a/patches/buffer-equal-constant-time@1.0.1.patch
+++ b/patches/buffer-equal-constant-time@1.0.1.patch
@@ -1,0 +1,18 @@
+diff --git a/.npmignore b/.npmignore
+deleted file mode 100644
+index 34e4f5c298de294fa5c1c1769b6489eb047bde9a..0000000000000000000000000000000000000000
+diff --git a/index.js b/index.js
+index 5462c1f830bdbe79bf2b1fcfd811cd9799b4dd11..bb9694049552b405fff2f4988378fbfec912e3ea 100644
+--- a/index.js
++++ b/index.js
+@@ -34,8 +34,8 @@ bufferEq.install = function() {
+ };
+ 
+ var origBufEqual = Buffer.prototype.equal;
+-var origSlowBufEqual = SlowBuffer.prototype.equal;
++var origSlowBufEqual = SlowBuffer ? SlowBuffer.prototype.equal : undefined;
+ bufferEq.restore = function() {
+   Buffer.prototype.equal = origBufEqual;
+-  SlowBuffer.prototype.equal = origSlowBufEqual;
++  if (SlowBuffer) SlowBuffer.prototype.equal = origSlowBufEqual;
+ };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  buffer-equal-constant-time@1.0.1: e03588c9a21029fdbec27eadb9009dd6f0355a13343f7e5c0f1973dc84cf62b2
+
 importers:
 
   .:
@@ -12,26 +15,26 @@ importers:
         specifier: ^4.10.3
         version: 4.10.3
       '@azure/keyvault-keys':
-        specifier: ^4.10.0
-        version: 4.10.0
+        specifier: ^4.10.2
+        version: 4.10.2
       '@azure/keyvault-secrets':
         specifier: ^4.11.2
         version: 4.11.2
       '@drunk-pulumi/azure-providers':
         specifier: ^1.0.16
-        version: 1.0.16(@types/node@25.9.1)
+        version: 1.0.16(@types/node@26.0.0)
       '@pulumi/azure-native':
-        specifier: ^3.18.0
-        version: 3.18.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))(typescript@6.0.3)
+        specifier: ^3.19.0
+        version: 3.19.0(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3))(typescript@6.0.3)
       '@pulumi/azuread':
         specifier: ^6.9.1
-        version: 6.9.1(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))(typescript@6.0.3)
+        version: 6.9.1(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3))(typescript@6.0.3)
       '@pulumi/pulumi':
-        specifier: ^3.243.0
-        version: 3.243.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))(typescript@6.0.3)
+        specifier: ^3.247.0
+        version: 3.247.0(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3))(typescript@6.0.3)
       '@pulumi/random':
         specifier: ^4.21.0
-        version: 4.21.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))(typescript@6.0.3)
+        version: 4.21.0(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3))(typescript@6.0.3)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -39,8 +42,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       openpgp:
-        specifier: ^6.3.0
-        version: 6.3.0
+        specifier: ^6.3.1
+        version: 6.3.1(@openpgp/web-stream-tools@0.0.11)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -55,8 +58,8 @@ importers:
         specifier: ^2.0.6
         version: 2.0.6
       '@types/node':
-        specifier: 25.9.1
-        version: 25.9.1
+        specifier: 26.0.0
+        version: 26.0.0
       cpy-cli:
         specifier: ^7.0.0
         version: 7.0.0
@@ -65,16 +68,16 @@ importers:
         version: 10.1.0
       jest:
         specifier: ^30.4.2
-        version: 30.4.2(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))
+        version: 30.4.2(@types/node@26.0.0)(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3))
       prettier:
-        specifier: ^3.8.3
-        version: 3.8.3
+        specifier: ^3.8.4
+        version: 3.8.4
       ts-jest:
         specifier: ^29.4.11
-        version: 29.4.11(@babel/core@7.28.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3)))(typescript@6.0.3)
+        version: 29.4.11(@babel/core@7.28.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@26.0.0)(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3)))(typescript@6.0.3)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@25.9.1)(typescript@6.0.3)
+        version: 10.9.2(@types/node@26.0.0)(typescript@6.0.3)
 
 packages:
 
@@ -138,10 +141,6 @@ packages:
     resolution: {integrity: sha512-f7IxTD15Qdux30s2qFARH+JxgwxWLG2Rlr4oSkPGuLWm+1p5y1+C04XGLA0vmX6EtqfutmjvpNmAfgwVIS5hpw==}
     engines: {node: '>=18.0.0'}
 
-  '@azure/core-http-compat@2.3.0':
-    resolution: {integrity: sha512-qLQujmUypBBG0gxHd0j6/Jdmul6ttl24c8WGiLXIk7IHXdBlfoBqW27hyz3Xn6xbfdyVSarl1Ttbk0AwnZBYCw==}
-    engines: {node: '>=18.0.0'}
-
   '@azure/core-lro@2.7.2':
     resolution: {integrity: sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==}
     engines: {node: '>=18.0.0'}
@@ -162,10 +161,6 @@ packages:
     resolution: {integrity: sha512-UKTiEJPkWcESPYJz3X5uKRYyOcJD+4nYph+KpfdPRnQJVrZfk0KJgdnaAWKfhsBBtAf/D58Az4AvCJEmWgIBAg==}
     engines: {node: '>=18.0.0'}
 
-  '@azure/core-util@1.12.0':
-    resolution: {integrity: sha512-13IyjTQgABPARvG90+N2dXpC+hwp466XCdQXPCRlbWHgd3SJd5Q1VvaBGv6k1BIa4MQm6hAF1UBU1m8QUxV8sQ==}
-    engines: {node: '>=18.0.0'}
-
   '@azure/core-util@1.13.1':
     resolution: {integrity: sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==}
     engines: {node: '>=20.0.0'}
@@ -178,25 +173,17 @@ packages:
     resolution: {integrity: sha512-PgQLfcgsqVPEN8+HYs9L/9sUxd1qkUQa8csuKPFRq3twiIE5Sm1me+1tmoNp5rPCdYoBJSNzi/FYpldHlDeHDw==}
     engines: {node: '>=20.0.0'}
 
-  '@azure/keyvault-common@2.0.0':
-    resolution: {integrity: sha512-wRLVaroQtOqfg60cxkzUkGKrKMsCP6uYXAOomOIysSMyt1/YM0eUn9LqieAWM8DLcU4+07Fio2YGpPeqUbpP9w==}
-    engines: {node: '>=18.0.0'}
-
   '@azure/keyvault-common@2.1.0':
     resolution: {integrity: sha512-aCDidWuKY06LWQ4x7/8TIXK6iRqTaRWRL3t7T+LC+j1b07HtoIsOxP/tU90G4jCSBn5TAyUTCtA4MS/y5Hudaw==}
     engines: {node: '>=20.0.0'}
 
-  '@azure/keyvault-keys@4.10.0':
-    resolution: {integrity: sha512-eDT7iXoBTRZ2n3fLiftuGJFD+yjkiB1GNqzU2KbY1TLYeXeSPVTVgn2eJ5vmRTZ11978jy2Kg2wI7xa9Tyr8ag==}
-    engines: {node: '>=18.0.0'}
+  '@azure/keyvault-keys@4.10.2':
+    resolution: {integrity: sha512-VmUSLbXRAbSzDD8grXHGPaknYs0SKr3yuf6U+d4XMpX4XuVYskNqbTTwXce0zR1LyxfTZm9rWEBcvs3vdYwCmQ==}
+    engines: {node: '>=20.0.0'}
 
   '@azure/keyvault-secrets@4.11.2':
     resolution: {integrity: sha512-ECj/kwZbZlQXj2kfWivSICbKwj6W3chmFhv8qUdauqYnjvZ0hWZBFSsZWux7W2nX3MP49PLUCusXk+hAg3pipg==}
     engines: {node: '>=20.0.0'}
-
-  '@azure/logger@1.2.0':
-    resolution: {integrity: sha512-0hKEzLhpw+ZTAfNJyRrn6s+V0nDWzXk9OjBr2TiGIu0OfMr5s2V4FpKLTAK3Ca5r5OKLbf4hkOGDPyiRjie/jA==}
-    engines: {node: '>=18.0.0'}
 
   '@azure/logger@1.3.0':
     resolution: {integrity: sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==}
@@ -785,17 +772,14 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
-  '@pulumi/azure-native@3.17.0':
-    resolution: {integrity: sha512-oOC0YKvsv2OkchpG1aGgv2nucrBdgN6FfkkLemFuBV9P6vGHFuJxllPA6GQRW7VlQ4kCwO/wDMmE5+1VzuE7Xw==}
-
-  '@pulumi/azure-native@3.18.0':
-    resolution: {integrity: sha512-Kv50uw442FfExUP/Za9PXBWvzqINvR9iHvLoI2LAl8ZfT9UmDuWJO+CNwVJv2ZRSI33amqnvQN+bzGPTrZH6ZQ==}
+  '@pulumi/azure-native@3.19.0':
+    resolution: {integrity: sha512-ucHbfBz18VblvCe36XqLyR4ofFoPvNYYhC8oaoHKQuu9xQuFCbGGLYG9ptDvVapUNztcxcqIvz/8nD7oxUHyag==}
 
   '@pulumi/azuread@6.9.1':
     resolution: {integrity: sha512-ip0+uLgmXVWqnrJkvpUMpLF7Dwy04mt/1+KY6/Gph/JeaMiNVP8kTQxq7070zM+Yqb/d2SR/6WjXwC8pkYYOJQ==}
 
-  '@pulumi/pulumi@3.235.0':
-    resolution: {integrity: sha512-rIKpDzquX2+OdP/e7wHujQ1VUYO8EXNADsua+AT2BOWpC3z0K8NB/9NYDsTSw/mfBdVz9vr0UdO7ljiKi06GSg==}
+  '@pulumi/pulumi@3.243.0':
+    resolution: {integrity: sha512-KRIBErgCj9+gsEG7fOo3xRvvhq3VGw8gnzVpbFiyW2Zqr84MCIKDDVmj4MZDt/61KOn3OapI4ia1/6dSg3qwzQ==}
     engines: {node: '>=20'}
     peerDependencies:
       ts-node: '>= 7.0.1 < 12'
@@ -806,8 +790,8 @@ packages:
       typescript:
         optional: true
 
-  '@pulumi/pulumi@3.243.0':
-    resolution: {integrity: sha512-KRIBErgCj9+gsEG7fOo3xRvvhq3VGw8gnzVpbFiyW2Zqr84MCIKDDVmj4MZDt/61KOn3OapI4ia1/6dSg3qwzQ==}
+  '@pulumi/pulumi@3.247.0':
+    resolution: {integrity: sha512-JaXgWfRaT8XLQaqy6MriSxnphuyE56EjD8enZcNSEZ9nWthuTLV6i+w7q1KdcDJKGuMEn6yBeZuBoNafQtx4XA==}
     engines: {node: '>=20'}
     peerDependencies:
       ts-node: '>= 7.0.1 < 12'
@@ -914,11 +898,11 @@ packages:
   '@types/netmask@2.0.6':
     resolution: {integrity: sha512-Ix9OqbTjSebDShQWvQte8++15zTgeInozzwMmH8NveMNobCRLGXdkz0ja3Z4GW3H/nUGRm0pJG6JKm2c86nJLQ==}
 
-  '@types/node@25.6.0':
-    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
-
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+
+  '@types/node@26.0.0':
+    resolution: {integrity: sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==}
 
   '@types/semver@7.7.0':
     resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
@@ -2085,9 +2069,14 @@ packages:
     resolution: {integrity: sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==}
     engines: {node: '>=18'}
 
-  openpgp@6.3.0:
-    resolution: {integrity: sha512-pLzCU8IgyKXPSO11eeharQkQ4GzOKNWhXq79pQarIRZEMt1/ssyr+MIuWBv1mNoenJLg04gvPx+fi4gcKZ4bag==}
-    engines: {node: '>= 18.0.0'}
+  openpgp@6.3.1:
+    resolution: {integrity: sha512-7oSPvmlKPojxFoyelT5DWPIAVmqWZh4qU/5pO6bdoShEtRpCw9Sye9IXUQj6EFM3XpgGssqccAr705YtTcLNQw==}
+    engines: {node: '>= 18.0.0', typescript: '>= 5.0.0'}
+    peerDependencies:
+      '@openpgp/web-stream-tools': ~0.3.0
+    peerDependenciesMeta:
+      '@openpgp/web-stream-tools':
+        optional: true
 
   p-event@6.0.1:
     resolution: {integrity: sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==}
@@ -2167,10 +2156,6 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -2187,8 +2172,8 @@ packages:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
 
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+  prettier@3.8.4:
+    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -2278,11 +2263,6 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
-    engines: {node: '>=10'}
     hasBin: true
 
   semver@7.8.1:
@@ -2516,11 +2496,11 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
 
-  undici-types@7.19.2:
-    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
-
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   undici@6.25.0:
     resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
@@ -2773,7 +2753,7 @@ snapshots:
   '@azure/core-auth@1.9.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-util': 1.12.0
+      '@azure/core-util': 1.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -2790,19 +2770,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/core-http-compat@2.3.0':
-    dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@azure/core-client': 1.9.4
-      '@azure/core-rest-pipeline': 1.20.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@azure/core-lro@2.7.2':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-util': 1.12.0
-      '@azure/logger': 1.2.0
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -2825,8 +2797,8 @@ snapshots:
       '@azure/abort-controller': 2.1.2
       '@azure/core-auth': 1.9.0
       '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
-      '@azure/logger': 1.2.0
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
       '@typespec/ts-http-runtime': 0.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -2835,14 +2807,6 @@ snapshots:
   '@azure/core-tracing@1.2.0':
     dependencies:
       tslib: 2.8.1
-
-  '@azure/core-util@1.12.0':
-    dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@typespec/ts-http-runtime': 0.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@azure/core-util@1.13.1':
     dependencies:
@@ -2884,19 +2848,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/keyvault-common@2.0.0':
-    dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
-      '@azure/core-rest-pipeline': 1.20.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
-      '@azure/logger': 1.2.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@azure/keyvault-common@2.1.0':
     dependencies:
       '@azure-rest/core-client': 2.5.0
@@ -2910,19 +2861,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/keyvault-keys@4.10.0':
+  '@azure/keyvault-keys@4.10.2':
     dependencies:
       '@azure-rest/core-client': 2.5.0
       '@azure/abort-controller': 2.1.2
       '@azure/core-auth': 1.9.0
-      '@azure/core-http-compat': 2.3.0
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
       '@azure/core-rest-pipeline': 1.20.0
       '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
-      '@azure/keyvault-common': 2.0.0
-      '@azure/logger': 1.2.0
+      '@azure/core-util': 1.13.1
+      '@azure/keyvault-common': 2.1.0
+      '@azure/logger': 1.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -2939,13 +2889,6 @@ snapshots:
       '@azure/core-util': 1.13.1
       '@azure/keyvault-common': 2.1.0
       '@azure/logger': 1.3.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@azure/logger@1.2.0':
-    dependencies:
-      '@typespec/ts-http-runtime': 0.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -3161,7 +3104,7 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@drunk-pulumi/azure-providers@1.0.16(@types/node@25.9.1)':
+  '@drunk-pulumi/azure-providers@1.0.16(@types/node@26.0.0)':
     dependencies:
       '@azure/arm-apimanagement': 10.0.0
       '@azure/arm-cdn': 9.1.0
@@ -3174,14 +3117,14 @@ snapshots:
       '@azure/arm-sql': 10.0.0
       '@azure/identity': 4.13.1
       '@azure/keyvault-certificates': 4.10.3
-      '@azure/keyvault-keys': 4.10.0
+      '@azure/keyvault-keys': 4.10.2
       '@azure/keyvault-secrets': 4.11.2
       '@openpgp/web-stream-tools': 0.0.11
-      '@pulumi/azure-native': 3.17.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))(typescript@6.0.3)
-      '@pulumi/pulumi': 3.235.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))(typescript@6.0.3)
+      '@pulumi/azure-native': 3.19.0(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3))(typescript@6.0.3)
+      '@pulumi/pulumi': 3.247.0(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3))(typescript@6.0.3)
       node-forge: 1.4.0
-      openpgp: 6.3.0
-      ts-node: 10.9.2(@types/node@25.9.1)(typescript@6.0.3)
+      openpgp: 6.3.1(@openpgp/web-stream-tools@0.0.11)
+      ts-node: 10.9.2(@types/node@26.0.0)(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@swc/core'
@@ -3249,13 +3192,13 @@ snapshots:
   '@jest/console@30.4.1':
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 25.6.0
+      '@types/node': 26.0.0
       chalk: 4.1.2
       jest-message-util: 30.4.1
       jest-util: 30.4.1
       slash: 3.0.0
 
-  '@jest/core@30.4.2(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))':
+  '@jest/core@30.4.2(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 30.4.1
       '@jest/pattern': 30.4.0
@@ -3263,7 +3206,7 @@ snapshots:
       '@jest/test-result': 30.4.1
       '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 25.6.0
+      '@types/node': 26.0.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.3.0
@@ -3271,7 +3214,7 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11
       jest-changed-files: 30.4.1
-      jest-config: 30.4.2(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))
+      jest-config: 30.4.2(@types/node@26.0.0)(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3))
       jest-haste-map: 30.4.1
       jest-message-util: 30.4.1
       jest-regex-util: 30.4.0
@@ -3299,7 +3242,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 25.6.0
+      '@types/node': 26.0.0
       jest-mock: 30.4.1
 
   '@jest/expect-utils@30.0.5':
@@ -3321,7 +3264,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.4.1
       '@sinonjs/fake-timers': 15.4.0
-      '@types/node': 25.6.0
+      '@types/node': 26.0.0
       jest-message-util: 30.4.1
       jest-mock: 30.4.1
       jest-util: 30.4.1
@@ -3341,12 +3284,12 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 26.0.0
       jest-regex-util: 30.0.1
 
   '@jest/pattern@30.4.0':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 26.0.0
       jest-regex-util: 30.4.0
 
   '@jest/reporters@30.4.1':
@@ -3357,7 +3300,7 @@ snapshots:
       '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
       '@jridgewell/trace-mapping': 0.3.29
-      '@types/node': 25.6.0
+      '@types/node': 26.0.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit-x: 0.2.2
@@ -3437,7 +3380,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.6.0
+      '@types/node': 26.0.0
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -3447,7 +3390,7 @@ snapshots:
       '@jest/schemas': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.6.0
+      '@types/node': 26.0.0
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -3537,7 +3480,7 @@ snapshots:
       proggy: 4.0.0
       promise-all-reject-late: 1.0.1
       promise-call-limit: 3.0.2
-      semver: 7.7.4
+      semver: 7.8.1
       ssri: 13.0.1
       treeverse: 3.0.0
       walk-up-path: 4.0.0
@@ -3546,7 +3489,7 @@ snapshots:
 
   '@npmcli/fs@5.0.0':
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.1
 
   '@npmcli/git@7.0.2':
     dependencies:
@@ -3556,7 +3499,7 @@ snapshots:
       lru-cache: 11.3.6
       npm-pick-manifest: 11.0.3
       proc-log: 6.1.0
-      semver: 7.7.4
+      semver: 7.8.1
       which: 6.0.1
 
   '@npmcli/installed-package-contents@4.0.0':
@@ -3577,7 +3520,7 @@ snapshots:
       json-parse-even-better-errors: 5.0.0
       pacote: 21.5.0
       proc-log: 6.1.0
-      semver: 7.7.4
+      semver: 7.8.1
     transitivePeerDependencies:
       - supports-color
 
@@ -3592,7 +3535,7 @@ snapshots:
       hosted-git-info: 9.0.3
       json-parse-even-better-errors: 5.0.0
       proc-log: 6.1.0
-      semver: 7.7.4
+      semver: 7.8.1
       spdx-expression-parse: 4.0.0
 
   '@npmcli/promise-spawn@9.0.1':
@@ -3667,7 +3610,7 @@ snapshots:
       '@types/shimmer': 1.2.0
       import-in-the-middle: 1.13.1
       require-in-the-middle: 7.5.2
-      semver: 7.7.4
+      semver: 7.8.1
       shimmer: 1.2.1
     transitivePeerDependencies:
       - supports-color
@@ -3741,7 +3684,7 @@ snapshots:
       '@opentelemetry/propagator-b3': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/propagator-jaeger': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
-      semver: 7.7.4
+      semver: 7.8.1
 
   '@opentelemetry/semantic-conventions@1.28.0': {}
 
@@ -3773,31 +3716,23 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
-  '@pulumi/azure-native@3.17.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))(typescript@6.0.3)':
+  '@pulumi/azure-native@3.19.0(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@pulumi/pulumi': 3.235.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))(typescript@6.0.3)
+      '@pulumi/pulumi': 3.243.0(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3))(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
       - ts-node
       - typescript
 
-  '@pulumi/azure-native@3.18.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))(typescript@6.0.3)':
+  '@pulumi/azuread@6.9.1(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@pulumi/pulumi': 3.235.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))(typescript@6.0.3)
+      '@pulumi/pulumi': 3.247.0(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3))(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
       - ts-node
       - typescript
 
-  '@pulumi/azuread@6.9.1(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))(typescript@6.0.3)':
-    dependencies:
-      '@pulumi/pulumi': 3.235.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))(typescript@6.0.3)
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
-      - typescript
-
-  '@pulumi/pulumi@3.235.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))(typescript@6.0.3)':
+  '@pulumi/pulumi@3.243.0(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
       '@grpc/grpc-js': 1.13.3
       '@logdna/tail-file': 2.2.0
@@ -3822,17 +3757,17 @@ snapshots:
       normalize-package-data: 6.0.2
       picomatch: 4.0.4
       require-from-string: 2.0.2
-      semver: 7.7.4
+      semver: 7.8.1
       source-map-support: 0.5.21
       tmp: 0.2.5
       upath: 1.2.0
     optionalDependencies:
-      ts-node: 10.9.2(@types/node@25.9.1)(typescript@6.0.3)
+      ts-node: 10.9.2(@types/node@26.0.0)(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@pulumi/pulumi@3.243.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))(typescript@6.0.3)':
+  '@pulumi/pulumi@3.247.0(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
       '@grpc/grpc-js': 1.13.3
       '@logdna/tail-file': 2.2.0
@@ -3857,19 +3792,19 @@ snapshots:
       normalize-package-data: 6.0.2
       picomatch: 4.0.4
       require-from-string: 2.0.2
-      semver: 7.7.4
+      semver: 7.8.1
       source-map-support: 0.5.21
       tmp: 0.2.5
       upath: 1.2.0
     optionalDependencies:
-      ts-node: 10.9.2(@types/node@25.9.1)(typescript@6.0.3)
+      ts-node: 10.9.2(@types/node@26.0.0)(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@pulumi/random@4.21.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))(typescript@6.0.3)':
+  '@pulumi/random@4.21.0(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@pulumi/pulumi': 3.235.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))(typescript@6.0.3)
+      '@pulumi/pulumi': 3.247.0(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3))(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -3981,13 +3916,13 @@ snapshots:
 
   '@types/netmask@2.0.6': {}
 
-  '@types/node@25.6.0':
-    dependencies:
-      undici-types: 7.19.2
-
   '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
+
+  '@types/node@26.0.0':
+    dependencies:
+      undici-types: 8.3.0
 
   '@types/semver@7.7.0': {}
 
@@ -4219,7 +4154,7 @@ snapshots:
     dependencies:
       node-int64: 0.4.0
 
-  buffer-equal-constant-time@1.0.1: {}
+  buffer-equal-constant-time@1.0.1(patch_hash=e03588c9a21029fdbec27eadb9009dd6f0355a13343f7e5c0f1973dc84cf62b2): {}
 
   buffer-from@1.1.2: {}
 
@@ -4631,7 +4566,7 @@ snapshots:
       '@babel/parser': 7.28.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.7.4
+      semver: 7.8.1
     transitivePeerDependencies:
       - supports-color
 
@@ -4672,7 +4607,7 @@ snapshots:
       '@jest/expect': 30.4.1
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 25.6.0
+      '@types/node': 26.0.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.6.0
@@ -4692,15 +4627,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.4.2(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3)):
+  jest-cli@30.4.2(@types/node@26.0.0)(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.4.2(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))
+      '@jest/core': 30.4.2(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3))
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.4.2(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))
+      jest-config: 30.4.2(@types/node@26.0.0)(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3))
       jest-util: 30.4.1
       jest-validate: 30.4.1
       yargs: 17.7.2
@@ -4711,7 +4646,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.4.2(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3)):
+  jest-config@30.4.2(@types/node@26.0.0)(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.28.0
       '@jest/get-type': 30.1.0
@@ -4737,40 +4672,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 25.6.0
-      ts-node: 10.9.2(@types/node@25.9.1)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.4.2(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3)):
-    dependencies:
-      '@babel/core': 7.28.0
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.4.0
-      '@jest/test-sequencer': 30.4.1
-      '@jest/types': 30.4.1
-      babel-jest: 30.4.1(@babel/core@7.28.0)
-      chalk: 4.1.2
-      ci-info: 4.3.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.4.2
-      jest-docblock: 30.4.0
-      jest-environment-node: 30.4.1
-      jest-regex-util: 30.4.0
-      jest-resolve: 30.4.1
-      jest-runner: 30.4.2
-      jest-util: 30.4.1
-      jest-validate: 30.4.1
-      parse-json: 5.2.0
-      pretty-format: 30.4.1
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.9.1
-      ts-node: 10.9.2(@types/node@25.9.1)(typescript@6.0.3)
+      '@types/node': 26.0.0
+      ts-node: 10.9.2(@types/node@26.0.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -4806,7 +4709,7 @@ snapshots:
       '@jest/environment': 30.4.1
       '@jest/fake-timers': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 25.6.0
+      '@types/node': 26.0.0
       jest-mock: 30.4.1
       jest-util: 30.4.1
       jest-validate: 30.4.1
@@ -4814,7 +4717,7 @@ snapshots:
   jest-haste-map@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 25.6.0
+      '@types/node': 26.0.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -4873,13 +4776,13 @@ snapshots:
   jest-mock@30.0.5:
     dependencies:
       '@jest/types': 30.0.5
-      '@types/node': 25.6.0
+      '@types/node': 26.0.0
       jest-util: 30.0.5
 
   jest-mock@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 25.6.0
+      '@types/node': 26.0.0
       jest-util: 30.4.1
 
   jest-pnp-resolver@1.2.3(jest-resolve@30.4.1):
@@ -4915,7 +4818,7 @@ snapshots:
       '@jest/test-result': 30.4.1
       '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 25.6.0
+      '@types/node': 26.0.0
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -4944,7 +4847,7 @@ snapshots:
       '@jest/test-result': 30.4.1
       '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 25.6.0
+      '@types/node': 26.0.0
       chalk: 4.1.2
       cjs-module-lexer: 2.1.0
       collect-v8-coverage: 1.0.2
@@ -4983,7 +4886,7 @@ snapshots:
       jest-message-util: 30.4.1
       jest-util: 30.4.1
       pretty-format: 30.4.1
-      semver: 7.7.4
+      semver: 7.8.1
       synckit: 0.11.11
     transitivePeerDependencies:
       - supports-color
@@ -4991,16 +4894,16 @@ snapshots:
   jest-util@30.0.5:
     dependencies:
       '@jest/types': 30.0.5
-      '@types/node': 25.6.0
+      '@types/node': 26.0.0
       chalk: 4.1.2
       ci-info: 4.3.0
       graceful-fs: 4.2.11
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   jest-util@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 25.6.0
+      '@types/node': 26.0.0
       chalk: 4.1.2
       ci-info: 4.3.0
       graceful-fs: 4.2.11
@@ -5019,7 +4922,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 25.6.0
+      '@types/node': 26.0.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -5028,18 +4931,18 @@ snapshots:
 
   jest-worker@30.4.1:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 26.0.0
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.4.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.4.2(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3)):
+  jest@30.4.2(@types/node@26.0.0)(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.4.2(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))
+      '@jest/core': 30.4.2(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3))
       '@jest/types': 30.4.1
       import-local: 3.2.0
-      jest-cli: 30.4.2(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))
+      jest-cli: 30.4.2(@types/node@26.0.0)(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -5079,7 +4982,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.7.4
+      semver: 7.8.1
 
   junk@4.0.1: {}
 
@@ -5089,7 +4992,7 @@ snapshots:
 
   jwa@1.4.1:
     dependencies:
-      buffer-equal-constant-time: 1.0.1
+      buffer-equal-constant-time: 1.0.1(patch_hash=e03588c9a21029fdbec27eadb9009dd6f0355a13343f7e5c0f1973dc84cf62b2)
       ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
 
@@ -5138,7 +5041,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.1
 
   make-error@1.3.6: {}
 
@@ -5247,7 +5150,7 @@ snapshots:
       graceful-fs: 4.2.11
       nopt: 9.0.0
       proc-log: 6.1.0
-      semver: 7.7.4
+      semver: 7.8.1
       tar: 7.5.14
       tinyglobby: 0.2.16
       undici: 6.25.0
@@ -5264,7 +5167,7 @@ snapshots:
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
-      semver: 7.7.4
+      semver: 7.8.1
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
@@ -5275,7 +5178,7 @@ snapshots:
 
   npm-install-checks@8.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.1
 
   npm-normalize-package-bin@5.0.0: {}
 
@@ -5283,7 +5186,7 @@ snapshots:
     dependencies:
       hosted-git-info: 9.0.3
       proc-log: 6.1.0
-      semver: 7.7.4
+      semver: 7.8.1
       validate-npm-package-name: 7.0.2
 
   npm-packlist@10.0.4:
@@ -5296,7 +5199,7 @@ snapshots:
       npm-install-checks: 8.0.0
       npm-normalize-package-bin: 5.0.0
       npm-package-arg: 13.0.2
-      semver: 7.7.4
+      semver: 7.8.1
 
   npm-registry-fetch@19.1.1:
     dependencies:
@@ -5330,7 +5233,9 @@ snapshots:
       is-inside-container: 1.0.0
       is-wsl: 3.1.0
 
-  openpgp@6.3.0: {}
+  openpgp@6.3.1(@openpgp/web-stream-tools@0.0.11):
+    optionalDependencies:
+      '@openpgp/web-stream-tools': 0.0.11
 
   p-event@6.0.1:
     dependencies:
@@ -5417,8 +5322,6 @@ snapshots:
 
   picomatch@2.3.1: {}
 
-  picomatch@4.0.3: {}
-
   picomatch@4.0.4: {}
 
   pirates@4.0.7: {}
@@ -5432,7 +5335,7 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  prettier@3.8.3: {}
+  prettier@3.8.4: {}
 
   pretty-format@30.0.5:
     dependencies:
@@ -5467,7 +5370,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 25.6.0
+      '@types/node': 25.9.1
       long: 5.3.2
 
   pure-rand@7.0.1: {}
@@ -5518,8 +5421,6 @@ snapshots:
     optional: true
 
   semver@6.3.1: {}
-
-  semver@7.7.4: {}
 
   semver@7.8.1: {}
 
@@ -5682,12 +5583,12 @@ snapshots:
 
   treeverse@3.0.0: {}
 
-  ts-jest@29.4.11(@babel/core@7.28.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3)))(typescript@6.0.3):
+  ts-jest@29.4.11(@babel/core@7.28.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@26.0.0)(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3)))(typescript@6.0.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.4.2(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))
+      jest: 30.4.2(@types/node@26.0.0)(ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -5702,14 +5603,14 @@ snapshots:
       babel-jest: 30.4.1(@babel/core@7.28.0)
       jest-util: 30.4.1
 
-  ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3):
+  ts-node@10.9.2(@types/node@26.0.0)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 25.9.1
+      '@types/node': 26.0.0
       acorn: 8.14.1
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -5741,9 +5642,9 @@ snapshots:
   uglify-js@3.19.3:
     optional: true
 
-  undici-types@7.19.2: {}
-
   undici-types@7.24.6: {}
+
+  undici-types@8.3.0: {}
 
   undici@6.25.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,6 @@ allowBuilds:
 
 minimumReleaseAgeExclude:
   - '@drunk-pulumi/azure-providers'
+
+patchedDependencies:
+  buffer-equal-constant-time@1.0.1: patches/buffer-equal-constant-time@1.0.1.patch

--- a/src/helpers/azureEnv.ts
+++ b/src/helpers/azureEnv.ts
@@ -6,7 +6,7 @@
 import { authorization } from '@pulumi/azure-native';
 import * as pulumi from '@pulumi/pulumi';
 import { getCountryCode, getRegionCode } from './Location';
-import { stack } from './stackEnv';
+import { stack, isTesting } from './stackEnv';
 
 /**
  * @enum {string}
@@ -29,7 +29,18 @@ const azEnv = JSON.parse(process.env.PULUMI_CONFIG ?? '{}');
  * @constant {Output} config
  * @description Azure client configuration output
  */
-const config = authorization.getClientConfigOutput();
+function getClientConfig() {
+  if (isTesting) {
+    return {
+      tenantId: pulumi.output(azEnv['azure-native:config:tenantId'] ?? ''),
+      subscriptionId: pulumi.output(azEnv['azure-native:config:subscriptionId'] ?? ''),
+      objectId: pulumi.output(''),
+    } as unknown as ReturnType<typeof authorization.getClientConfigOutput>;
+  }
+  return authorization.getClientConfigOutput();
+}
+
+const config = getClientConfig();
 
 /**
  * @constant {Output<string>} tenantId
@@ -123,18 +134,19 @@ function getCurrentEnv() {
  */
 export const currentEnv = getCurrentEnv();
 
-//Print and Check
-pulumi.all([subscriptionId, tenantId, currentPrincipal]).apply(([s, t, p]) => {
-  console.log(`Azure Environment:`, {
-    tenantId: t,
-    subscriptionId: s,
-    principalId: p,
-    currentRegionCode,
-    currentRegionName,
-    currentCountryCode,
-    currentEnv,
+if (!isTesting) {
+  pulumi.all([subscriptionId, tenantId, currentPrincipal]).apply(([s, t, p]) => {
+    console.log(`Azure Environment:`, {
+      tenantId: t,
+      subscriptionId: s,
+      principalId: p,
+      currentRegionCode,
+      currentRegionName,
+      currentCountryCode,
+      currentEnv,
+    });
   });
-});
+}
 
 export const entraIdAuthorityUrl = pulumi.interpolate`https://login.microsoftonline.com/${tenantId}/v2.0`;
 

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": true,
+    "module": "CommonJS",
+    "moduleResolution": "node16",
+    "ignoreDeprecations": "6.0",
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*.ts", "__tests__/**/*.ts"]
+}


### PR DESCRIPTION
## Dependency Updates

| Package | From | To | Type |
|---------|------|----|------|
| @azure/keyvault-keys | ^4.10.0 | ^4.10.2 | patch |
| @pulumi/azure-native | ^3.18.0 | ^3.19.0 | minor |
| @pulumi/pulumi | ^3.243.0 | ^3.247.0 | minor |
| openpgp | ^6.3.0 | ^6.3.1 | patch |
| @types/node | 25.9.1 | 26.0.0 | **major** |
| prettier | ^3.8.3 | ^3.8.4 | patch |
| pnpm | 11.3.0 | 11.8.0 | minor |

## Code Changes for Breaking Upgrades

- **@types/node 26 → Node 26 runtime compatibility**: Patched `buffer-equal-constant-time@1.0.1` (transitive dep via jsonwebtoken → @azure/identity) which accessed removed `SlowBuffer` API in Node 26. Applied pnpm patch.
- **Jest 30 / TypeScript 6 compatibility**: Created `tsconfig.test.json` with proper `isolatedModules` and test type resolution. Updated `jest.config.js` to use it.
- **Test infrastructure fixes**: Replaced `jest.spyOn(globalThis, 'fetch')` with direct assignment (Jest 30 validates property existence). Replaced dynamic `import()` with static imports to avoid `--experimental-vm-modules` requirement.

## Enhancements

- Guarded module-level Pulumi engine calls in `azureEnv.ts` behind `isTesting` check so tests can run without a Pulumi engine.
- Updated `AppContainerEnv.test.ts` to use current `logs` API shape (was using removed `logAnalyticsWorkspace`).
- Fixed `ApimPolicyBuilder.test.ts` removing assertion for a header that was never set by the builder.
- All **20 tests pass**, **build succeeds**.